### PR TITLE
[FEATURE] Add forge credentials to travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ notifications:
   email: false
 deploy:
   provider: puppetforge
-  user: puppet
+  user: noerdisch
   password:
-    secure: ""
+    secure: "PkoBu3350FfZF67aKgR2ua59xAAwRb+2lERzpseoa4+9fWItP8UVCxxA269+6HZ/1ltPE/5AYqbE7oiJaCF8SnVFOmP8sfVG2n1roZXDrPaOPBRYzAkXgH4Dk6ZWdEX5y3i//ocv/6j932BS58amSoOyC/EO5GveY2elZ+bZeS1ICe1AG5HRIYGDQbVyStWH+UD8tlRJ8f1bLj+nnPTS7RRQfu/jD+t6Ux5nsZxXI6HNK2i9yCZdVNVbhvrc9KzGpw93lkABh2VYcZ65Oz/HwtY9oQX7w5DR7zKUwFjK0N7D39154pZTZpsTXc5wa1RDYPqVZzXmuj706FF3z3Cqt0JC5lrmodEJNhG7QantgS0aqxrMzaXWg/erxDbjN4cTnxgiYCVFlZIWmA9aLCrI3g6zwTdAovsNYYTw81EA7f/8Pap8obFurADYRO06jRsq9gHhSnzS+199dYaOWC77hLtEXZBftex2QiGyErQFgzGlBldyJeAaW1HaB/wmvPuYXalEDYKWTuhatynnjykD77ZoyF/+CRjatOPfjI9oHVOQC/5sZetojGNUTn61+NHtMWqhaVqE7Xw3cRhBm1pYSQGcI5DoKajF3XWQqots3UV9sYz2Zo0BbK14w9PDMsey2h0quS2F3cp+fWHSGutT9Pg4NcxgyFKKVn6kHPs8Hgw="
   on:
     tags: true
     all_branches: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class codeception {
     }
 
     exec { 'Add chrome to sourcelist':
-      command => 'sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'',
+      command => 'sudo sh -c \'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list\'',
     }
 
     exec { 'chrome_install':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,16 +14,19 @@ class codeception {
   if $::osfamily == 'Debian' {
     exec { 'download chrome source':
       command => 'wget -N https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -P ~/',
+      path    => '/usr/bin:/usr/sbin',
     }
 
     exec { 'install chrome':
       command => 'sudo dpkg -i --force-depends ~/google-chrome-stable_current_amd64.deb && sudo apt-get -f install -y',
+      path    => '/usr/bin:/usr/sbin',
     }
   }
 
   if $::osfamily == 'Debian' {
     exec { 'chromedriver_install':
       command => 'wget https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip -P ~/ && unzip ~/chromedriver_linux64.zip -d ~/ && rm ~/chromedriver_linux64.zip && sudo mv -f ~/chromedriver /usr/local/bin/chromedriver',
+      path    => '/usr/bin:/usr/sbin',
     }
     -> file {
         '/usr/local/bin/chromedriver': ensure => present, owner => 'root', group => 'root', mode => '0755',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,16 @@
 #   include codeception
 class codeception {
   if $::osfamily == 'Debian' {
+    exec { 'key signing chrome':
+      command => 'wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -',
+    }
+
+    exec { 'Add chrome to sourcelist':
+      command => 'sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'',
+    }
+
     exec { 'chrome_install':
-      command => 'sudo apt-get install google-chrome-stable',
+      command => 'sudo apt-get update && sudo apt-get install google-chrome-stable',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,13 +12,18 @@
 #   include codeception
 class codeception {
   if $::osfamily == 'Debian' {
-    exec { 'download chrome source':
-      command => 'wget -N https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -P ~/',
+    exec { 'key signing chrome':
+      command => 'wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -',
       path    => '/usr/bin:/usr/sbin',
     }
 
-    exec { 'install chrome':
-      command => 'sudo dpkg -i --force-depends ~/google-chrome-stable_current_amd64.deb && sudo apt-get -f install -y',
+    exec { 'Add chrome to sourcelist':
+      command => 'sudo sh -c \'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list\'',
+      path    => '/usr/bin:/usr/sbin',
+    }
+
+    exec { 'chrome_install':
+      command => 'sudo apt-get update && sudo apt-get install google-chrome-stable',
       path    => '/usr/bin:/usr/sbin',
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,16 +12,12 @@
 #   include codeception
 class codeception {
   if $::osfamily == 'Debian' {
-    exec { 'key signing chrome':
-      command => 'wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -',
+    exec { 'download chrome source':
+      command => 'wget -N https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -P ~/',
     }
 
-    exec { 'Add chrome to sourcelist':
-      command => 'sudo sh -c \'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list\'',
-    }
-
-    exec { 'chrome_install':
-      command => 'sudo apt-get update && sudo apt-get install google-chrome-stable',
+    exec { 'install chrome':
+      command => 'sudo dpkg -i --force-depends ~/google-chrome-stable_current_amd64.deb && sudo apt-get -f install -y',
     }
   }
 


### PR DESCRIPTION
Adding forge credentials to the travis CI configuration.
This can be used to publish releases directly by Travis CI.

Resolves: #3