### PR TITLE
Feature: cleanup processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I tested this actualy only on ubuntu 16.04.
 To use this module, add this declaration to your Puppetfile:
 
 ```
-mod 'noerdisch-codeception', '0.1.5'
+mod 'noerdisch-codeception', '0.1.6'
 ```
 
 ### Manually via puppet
@@ -31,7 +31,7 @@ mod 'noerdisch-codeception', '0.1.5'
 To manually install this module with puppet module tool:
 
 ```
-puppet module install noerdisch-codeception --version 0.1.5
+puppet module install noerdisch-codeception --version 0.1.6
 ```
 
 ### Via git

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,4 +65,14 @@ class codeception {
   file {
     '/usr/local/bin/stop-typo3-listener': ensure => file, content => template('codeception/stop-typo3-listener.sh.erb'), owner => 'root', group => 'root', mode => '0755'
   }
+
+  exec { 'Cleanup chrome process':
+    command => 'sudo rm ~/chromedriver.pid',
+    path    => '/usr/bin:/usr/sbin',
+  }
+
+  exec { 'Cleanup typo3 listener process':
+    command => 'sudo rm ~/typo3-listener.pid',
+    path    => '/usr/bin:/usr/sbin',
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "noerdisch-codeception",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Markus Günther",
   "summary": "Installing global codeception and some related tools like chromedriver.",
   "license": "MIT",


### PR DESCRIPTION
We have two pid files in the home folder that saves the chrome and typo3 listener process id.
This can be cleaned up while provision because the process is not there anymore.