### PR TITLE
Fix ordering violation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,9 @@ class codeception {
     }
 
     exec { 'chrome_install':
-      command => 'sudo apt-get update && sudo apt-get install google-chrome-stable',
+      command => 'sudo apt-get update && sudo apt-get install google-chrome-stable -y',
       path    => '/usr/bin:/usr/sbin',
+      require => Exec['Add chrome to sourcelist'],
     }
   }
 


### PR DESCRIPTION
Hello there!

This pull request fixes an ordering violation that appears in this module.
Specifically, the `Exec[add chrome to sourcelist]` must be always processed before the `Exec[chrome_install]` resource.

This is the error I get when Puppet processes resources in the erroneous order.

```
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:1 http://security.debian.org/debian-security stretch/updates InRelease [94.3 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Ign:2 http://deb.debian.org/debian stretch InRelease
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:3 http://deb.debian.org/debian stretch-updates InRelease [91.0 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Ign:4 http://apt.puppetlabs.com stretch InRelease
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:5 http://apt.puppetlabs.com stretch Release [55.6 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:6 http://apt.puppetlabs.com stretch Release.gpg [819 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:7 http://deb.debian.org/debian stretch Release [118 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:8 http://deb.debian.org/debian stretch Release.gpg [2434 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [474 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:10 http://deb.debian.org/debian stretch-updates/main amd64 Packages.diff/Index [7132 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages 2019-01-26-1412.04.pdiff [3276 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages 2019-01-26-1412.04.pdiff [3276 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:12 http://deb.debian.org/debian stretch/main amd64 Packages [7084 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:13 http://apt.puppetlabs.com stretch/puppet5 all Packages [8276 B]
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Get:14 http://apt.puppetlabs.com stretch/puppet5 amd64 Packages [140 kB] 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Fetched 8078 kB in 4s (1841 kB/s)
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Reading package lists...
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Reading package lists...
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Building dependency tree...
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Reading state information...
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: Package google-chrome-stable is not available, but is referred to by another package.
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: This may mean that the package is missing, has been obsoleted, or
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: is only available from another source
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: 
 Notice: /Stage[main]/Codeception/Exec[chrome_install]/returns: E: Package 'google-chrome-stable' has no installation candidate
 Error: sudo apt-get update && sudo apt-get install google-chrome-stable returned 100 instead of one of [0] 
 Error: /Stage[main]/Codeception/Exec[chrome_install]/returns: change from notrun to 0 failed: sudo apt-get update && sudo apt-get install google-chrome-stable returned 100 instead of one    of [0]
 Notice: /Stage[main]/Codeception/Exec[Add chrome to sourcelist]/returns: executed successfully
```